### PR TITLE
update use statements

### DIFF
--- a/code/extensions/UploadFieldExtension.php
+++ b/code/extensions/UploadFieldExtension.php
@@ -8,9 +8,9 @@
  * @credit micschk <https://github.com/micschk>
  */
 
-use SS_HTTPRequest;
-use Extension;
-use Folder;
+use SS_HTTPRequest as SS_HTTPRequest;
+use Extension as Extension;
+use Folder as Folder;
 
 class UploadFieldExtension extends Extension {
 	private static $allowed_actions = [

--- a/code/forms/EditableBlockRow.php
+++ b/code/forms/EditableBlockRow.php
@@ -8,14 +8,14 @@
  * @author Mellisa Hankins <mell@milkywaymultimedia.com.au>
  */
 
-use RequestHandler;
-use GridField_HTMLProvider;
-use GridField_SaveHandler;
-use GridField_URLHandler;
-use GridField_ColumnProvider;
-use Validator;
-use FieldList;
-use Session;
+use RequestHandler as RequestHandler;
+use GridField_HTMLProvider as GridField_HTMLProvider;
+use GridField_SaveHandler as GridField_SaveHandler;
+use GridField_URLHandler as GridField_URLHandler;
+use GridField_ColumnProvider as GridField_ColumnProvider;
+use Validator as Validator;
+use FieldList as FieldList;
+use Session as Session;
 
 class EditableBlockRow extends RequestHandler implements GridField_HTMLProvider, GridField_SaveHandler, GridField_URLHandler, GridField_ColumnProvider
 {


### PR DESCRIPTION
The `use` statements throw a warning when not used as a compound with `as`
